### PR TITLE
deps: migrate to apache-avro in place of avro-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0] - 2022-09-11
+### Breaking Change
+- Use `apache_avro == 0.14.0` in place of `avro-rs`
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schema-registry-client"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,7 +10,7 @@ edition = "2021"
 thiserror = "1.0"
 
 ## HTTP Client
-isahc = { version = "1.7.0", default-features = false, features = [
+isahc = { version = "1.7", default-features = false, features = [
     "json",
     "static-ssl",
     "static-curl",
@@ -21,22 +21,23 @@ isahc = { version = "1.7.0", default-features = false, features = [
 ## Serialize/Deserialize
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-strum = { version = "0.24.0", features = ["derive"] }
+strum = { version = "0.24", features = ["derive"] }
 
-avro-rs = { version = "0.13.0" }
-async-trait = "0.1.53"
+apache-avro = { version = "0.14.0" }
+
+async-trait = "0.1"
 
 ## Logging
 tracing = "0.1"
-async-lock = "2.5.0"
+async-lock = "2.5"
 
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-rand = "0.8.5"
+rand = "0.8"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
     "fmt",
     "json",
 ] }
-async-trait = "0.1.53"
+async-trait = "0.1"

--- a/src/client/srclient.rs
+++ b/src/client/srclient.rs
@@ -1,8 +1,8 @@
 use crate::client::types::*;
 use crate::client::ResponseExt;
 use crate::errors::SRError;
+use apache_avro::Schema;
 use async_lock::Mutex;
-use avro_rs::Schema;
 use isahc::{
     auth::{Authentication, Credentials},
     config::{RedirectPolicy, VersionNegotiation},
@@ -170,7 +170,7 @@ mod tests {
 
     use super::*;
     use crate::FromFile;
-    use avro_rs::Schema;
+    use apache_avro::Schema;
 
     fn test_client() -> SchemaRegistryClient {
         let url = "http://localhost:8081";

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,7 +32,7 @@ pub enum SRError {
     IO(#[from] std::io::Error),
 
     #[error("Schema parsing error")]
-    Schema(#[from] avro_rs::Error),
+    Schema(#[from] apache_avro::Error),
 
     #[error("Serializing/Deserializing error  {source}")]
     Serde {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod client;
 pub use client::{types, SchemaRegistryClient};
 pub use serde_ext::SerdeExt;
 mod serde_ext;
-pub use avro_rs;
+pub use apache_avro;
 pub mod prelude {
     pub use super::schema::FromFile;
     pub use super::types::*;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,9 +1,9 @@
 //!
 //! Helper traits to assist the Schema object.
-//! This can be used to read a file and convert it to avro_rs::Schema object.
+//! This can be used to read a file and convert it to apache_avro::Schema object.
 //!
 //! ```rust,no_run
-//! use avro_rs::Schema;
+//! use apache_avro::Schema;
 //! use schema_registry_client::prelude::*;
 //! use schema_registry_client::FromFile;
 //! let schema = Schema::parse_file("path/to/avsc/file").unwrap();
@@ -11,7 +11,7 @@
 //!
 
 use crate::errors::*;
-use avro_rs::Schema;
+use apache_avro::Schema;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;


### PR DESCRIPTION
`apache-avro` is the new home for avro related changes in Rust. `avro-rs` has now been deprecated.